### PR TITLE
Bump to v2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:alpine
 
 LABEL name="shfmt"
-LABEL version="2.5.0"
+LABEL version="2.5.1"
 
 ENV GOOS linux
 ENV CGO_ENABLED 0
-ENV SHFMT_VERSION 2.5.0
+ENV SHFMT_VERSION 2.5.1
 
 RUN apk add --no-cache git \
       && go get -u mvdan.cc/sh/cmd/shfmt \


### PR DESCRIPTION
Had a failure/stall with 2.5.0, but I don't think this will necessarily resolve it